### PR TITLE
reverse-historical-data-sorting-order

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -59,7 +59,7 @@ function processHistoricalData(rawData) {
 		const sortedData = series.data.sort((a, b) => {
 			const dateA = new Date(parseInt(a.year), parseInt(a.period.slice(1)) - 1);
 			const dateB = new Date(parseInt(b.year), parseInt(b.period.slice(1)) - 1);
-			return dateA - dateB;
+			return dateB - dateA;
 		});
 
 		if (sortedData[0]) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -3,6 +3,12 @@ const SERIES_IDS = {
 	milk: 'APU0000709112',
 	bread: 'APU0000702111',
 	gas: 'APU000074714',
+	bacon: 'APU0000704111',
+	bananas: 'APU0000703111',
+	chicken: 'APU0000706111',
+	oranges: 'APU0000711311',
+	coffee: 'APU0000717311',
+	electricity: 'APU000072610',
 };
 
 async function fetchHistoricalData(startYear, endYear, apiKey) {
@@ -102,7 +108,7 @@ export default {
 			console.log('Starting scheduled data fetch...');
 
 			const currentYear = new Date().getFullYear();
-			const startYear = currentYear - 20;
+			const startYear = currentYear - 10;
 
 			console.log(`Fetching data from ${startYear} to ${currentYear}...`);
 


### PR DESCRIPTION
# Reverse Historical Data Sorting and Expand Product List

## Changes
- Reversed the sorting order for historical data from oldest to newest to newest to oldest
- Expanded the product list to include more consumer goods
- Adjusted the historical data fetch range from 20 to 10 years

## Why
- Prioritizing recent data points improves data presentation and analysis
- A more comprehensive product list provides better insights into consumer goods prices
- Focusing on the last 10 years optimizes API usage and emphasizes recent trends

## Technical Details
- Modified the sorting function in `processHistoricalData` to use descending order
- Added new products: bacon, bananas, chicken, oranges, coffee, and electricity
- Updated the data fetch range parameter from 20 to 10 years

## Testing
- Verify that historical data is now displayed from newest to oldest
- Confirm that the new products are correctly tracked and displayed
- Ensure that the data fetch only retrieves the last 10 years of data

## Next Steps
- Monitor the impact of these changes on data analysis and user experience
- Consider adding more products or adjusting the data range based on user feedback