### PR TITLE
feat: Update citrus dataKey in goods.json

### DIFF
--- a/src/goods.json
+++ b/src/goods.json
@@ -150,7 +150,7 @@
 				},
 				"citrus": {
 					"name": "Oranges",
-					"dataKey": "oranges",
+					"dataKey": "citrus",
 					"icon": "🍊",
 					"unit": "pound",
 					"bgColor": "bg-orange-50",


### PR DESCRIPTION
Change the dataKey for oranges from "oranges" to "citrus" in the
goods.json file. This update ensures consistency between the
category name and its corresponding dataKey, improving data
organization and reducing potential confusion in the codebase.