### PR TITLE
feat: update vehicle data structure

### DIFF
--- a/src/goods.json
+++ b/src/goods.json
@@ -58,21 +58,19 @@
 		"vehicles": {
 			"name": "Vehicles",
 			"items": {
-				"new": {
+				"new_cars_and_trucks": {
 					"name": "New Cars and Trucks",
-					"dataKey": "new_cars",
+					"dataKey": "new_cars_and_trucks",
 					"icon": "🚗",
-					"unit": "unit",
 					"bgColor": "bg-blue-50",
 					"lineColor": "#3b82f6",
 					"seriesId": {
 						"national": "CUSR0000SS4501A"
 					},
-					"used": {
+					"used_cars_and_trucks": {
 						"name": "Used Cars and Trucks",
-						"dataKey": "used_cars",
+						"dataKey": "used_cars_and_trucks",
 						"icon": "🚚",
-						"unit": "unit",
 						"bgColor": "bg-blue-50",
 						"lineColor": "#3b82f6",
 						"seriesId": {


### PR DESCRIPTION
Update vehicle items' keys and dataKeys for consistency. Rename 'new' to 'new_cars_and_trucks' and 'used' to 'used_cars_and_trucks' to match their dataKey values. Remove unnecessary 'unit' field from both vehicle types as it's not needed for proper data handling.