### PR TITLE
feat: expand goods catalog to 27 items across 6 categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,9 @@ dist
 
 .dev.vars
 .wrangler/
+
+# AI Agent folders
+.claude/
+.anthropic/
+# Keep the plans, but maybe ignore the draft/temp ones
+docs/plans/*.tmp.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,39 @@
-# CLAUDE.md - Guidelines for POG-Cache
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Commands
-- Build/Deploy: `wrangler deploy`
-- Development: `wrangler dev` or `yarn dev`
-- Run all tests: `yarn test` or `vitest`
-- Run single test: `vitest run test/index.spec.js -t "test description"`
-- Watch tests: `vitest watch`
+- **Deploy:** `wrangler deploy`
+- **Dev server:** `wrangler dev` or `yarn dev`
+- **Run all tests:** `yarn test` or `vitest`
+- **Run single test:** `vitest run test/index.spec.js -t "test description"`
+- **Watch tests:** `vitest watch`
+
+## Architecture
+
+POG-Cache is a Cloudflare Worker that fetches Consumer Price Index (CPI) data from the BLS (Bureau of Labor Statistics) API and caches it in Cloudflare R2 storage. It runs on a daily cron schedule (midnight UTC).
+
+### Data flow
+1. `scheduled` handler triggers daily (or manually via `POST /update` with Bearer token auth)
+2. For each of the 5 US regions (national, northeast, midwest, south, west), the worker batch-fetches all BLS series IDs defined in `src/goods.json`
+3. BLS API responses are processed per-series: each series is matched back to its item in `goods.json` via `findItemBySeriesId()`
+4. Individual item data is stored to R2 at `{region}/{itemKey}.json`
+5. The full `goods.json` manifest is also uploaded to R2
+
+### Key files
+- `src/worker.js` — Single worker file with `scheduled` (cron) and `fetch` (HTTP) handlers
+- `src/goods.json` — Item catalog defining categories, items, BLS series IDs per region, and display metadata (icons, colors)
+- `wrangler.toml` — Worker config: cron trigger, R2 bucket binding (`POGCACHE_R2_BUCKET`)
+
+### Environment variables (via `env` object)
+- `BLS_API_KEY` — BLS API registration key
+- `UPDATE_TOKEN` — Bearer token for manual `/update` endpoint
+- `POGCACHE_R2_BUCKET` — R2 bucket binding (configured in wrangler.toml)
+
+### Testing
+Tests use `@cloudflare/vitest-pool-workers` which runs vitest inside the Workers runtime. Config is in `vitest.config.js` with wrangler.toml providing the worker configuration.
 
 ## Code Style
-- **JS Style**: Modern ES modules with async/await patterns
-- **Naming**: camelCase for variables/functions, PascalCase for classes
-- **Imports**: List external imports first, then internal
-- **Functions**: Use arrow functions for callbacks, named functions for exports
-- **Error Handling**: Use try/catch blocks with specific error messages
-- **Logging**: Consistent format with emojis for status (✓, ❌, ⚠️)
-- **Data Structure**: Follow existing patterns in goods.json
-- **API Calls**: Use fetch API with proper error handling
-- **Config**: Use environment variables via Cloudflare Workers env object
-
-This codebase is a Cloudflare Worker that fetches and caches data from the BLS API.
+- **Formatting:** Tabs, single quotes, semicolons, 140 char print width (see `.prettierrc`)
+- **Indentation:** Tabs for all files, spaces for YAML (see `.editorconfig`)
+- **Console logging:** Uses emoji prefixes for status — `✓` success, `❌` error, `⚠️` warning

--- a/docs/plans/2026-01-31-expand-goods-catalog-design.md
+++ b/docs/plans/2026-01-31-expand-goods-catalog-design.md
@@ -1,0 +1,127 @@
+# Expand Goods Catalog
+
+**Date:** 2026-01-31
+**Status:** Ready
+
+## Goal
+
+Expand the goods catalog from 15 items across 4 categories to 27 items across 6 categories. Restructure categories to be more logical (eggs moved to dairy, produce split into fruits/vegetables, new pantry category including coffee).
+
+## What Changes
+
+- **`src/goods.json`** -- restructured categories and 12 new items added
+- **`src/worker.js`** -- no changes needed (iterates `categories` generically)
+- **R2 storage** -- new item keys appear automatically at `{region}/{itemKey}.json`
+
+## Constraints
+
+- BLS API v2 allows 50 series per batch request. At 27 items per region, we stay under the limit.
+- 27 items x 5 regions = 135 total series (up from 75).
+- All series IDs verified against the BLS API on 2026-01-31.
+
+## Category Structure
+
+### Proteins (5 items)
+
+| Key | Name | Unit | Icon | National | Northeast | Midwest | South | West |
+|-----|------|------|------|----------|-----------|---------|-------|------|
+| chicken | Chicken | pound | `🐔` | APU0000706111 | APU0100706111 | APU0200706111 | APU0300706111 | APU0400706111 |
+| ground_beef | Ground Beef | pound | `🥩` | APU0000703112 | APU0100703112 | APU0200703112 | APU0300703112 | APU0400703112 |
+| bacon | Bacon | pound | `🥓` | APU0000704111 | APU0100704111 | APU0200704111 | APU0300704111 | APU0400704111 |
+| pork_chops | Pork Chops | pound | `🍖` | APU0000FD3101 | APU0100FD3101 | APU0200FD3101 | APU0300FD3101 | APU0400FD3101 |
+| ham | Ham | pound | `🐷` | APU0000FD2101 | APU0100FD2101 | APU0200FD2101 | APU0300FD2101 | APU0400FD2101 |
+
+### Dairy & Eggs (6 items)
+
+| Key | Name | Unit | Icon | National | Northeast | Midwest | South | West |
+|-----|------|------|------|----------|-----------|---------|-------|------|
+| eggs | Eggs | dozen | `🥚` | APU0000708111 | APU0100708111 | APU0200708111 | APU0300708111 | APU0400708112 |
+| milk | Whole Milk | gallon | `🥛` | APU0000709112 | APU0100709112 | APU0200709112 | APU0300709112 | APU0400709112 |
+| cheese | Cheese | pound | `🧀` | APU0000710212 | APU0100710212 | APU0200710212 | APU0300710212 | APU0400710212 |
+| ice_cream | Ice Cream | half gallon | `🍨` | APU0000710411 | APU0100710411 | APU0200710411 | APU0300710411 | APU0400710411 |
+| butter | Butter | pound | `🧈` | APU0000FS1101 | APU0100FS1101 | APU0200FS1101 | APU0300FS1101 | APU0400FS1101 |
+| yogurt | Yogurt | 8 oz | `🫙` | APU0000FJ4101 | APU0100FJ4101 | APU0200FJ4101 | APU0300FJ4101 | APU0400FJ4101 |
+
+### Fruits (4 items)
+
+| Key | Name | Unit | Icon | National | Northeast | Midwest | South | West |
+|-----|------|------|------|----------|-----------|---------|-------|------|
+| bananas | Bananas | pound | `🍌` | APU0000711211 | APU0100711211 | APU0200711211 | APU0300711211 | APU0400711211 |
+| apples | Apples | pound | `🍎` | APU0000711311 | APU0100711311 | APU0200711311 | APU0300711311 | APU0400711311 |
+| citrus | Oranges | pound | `🍊` | APU0000711411 | APU0100711411 | APU0200711411 | APU0300711411 | APU0400711411 |
+| strawberries | Strawberries | 12 oz | `🍓` | APU0000711415 | APU0100711415 | APU0200711415 | APU0300711415 | APU0400711415 |
+
+### Vegetables (3 items)
+
+| Key | Name | Unit | Icon | National | Northeast | Midwest | South | West |
+|-----|------|------|------|----------|-----------|---------|-------|------|
+| potatoes | Potatoes | pound | `🥔` | APU0000712112 | APU0100712112 | APU0200712112 | APU0300712112 | APU0400712112 |
+| lettuce | Lettuce | pound | `🥬` | APU0000712211 | APU0100712211 | APU0200712211 | APU0300712211 | APU0400712211 |
+| tomatoes | Tomatoes | pound | `🍅` | APU0000712311 | APU0100712311 | APU0200712311 | APU0300712311 | APU0400712311 |
+
+### Pantry (6 items)
+
+| Key | Name | Unit | Icon | National | Northeast | Midwest | South | West |
+|-----|------|------|------|----------|-----------|---------|-------|------|
+| white_bread | White Bread | pound | `🍞` | APU0000702111 | APU0100702111 | APU0200702111 | APU0300702111 | APU0400702111 |
+| whole_wheat_bread | Whole Wheat Bread | pound | `🌾` | APU0000702212 | APU0100702212 | APU0200702212 | APU0300702212 | APU0400702212 |
+| rice | Rice | pound | `🍚` | APU0000701312 | APU0100701312 | APU0200701312 | APU0300701312 | APU0400701312 |
+| spaghetti | Spaghetti & Macaroni | pound | `🍝` | APU0000701322 | APU0100701322 | APU0200701322 | APU0300701322 | APU0400701322 |
+| flour | Flour | pound | `🌿` | APU0000701111 | APU0100701111 | APU0200701111 | APU0300701111 | APU0400701111 |
+| coffee | Coffee | pound | `☕` | APU0000717311 | APU0100717311 | APU0200717311 | APU0300717311 | APU0400717311 |
+
+### Energy (3 items)
+
+| Key | Name | Unit | Icon | National | Northeast | Midwest | South | West |
+|-----|------|------|------|----------|-----------|---------|-------|------|
+| gas | Unleaded Regular Gas | gallon | `⛽` | APU000074714 | APU010074714 | APU020074714 | APU030074714 | APU040074714 |
+| electricity | Electricity | KWH | `💡` | APU000072610 | APU010072610 | APU020072610 | APU030072610 | APU040072610 |
+| natural_gas | Natural Gas | therm | `🔥` | APU000072620 | APU010072620 | APU020072620 | APU030072620 | APU040072620 |
+
+## Display Metadata (new items)
+
+Colors should complement existing items within each category:
+
+| Item | bgColor | lineColor |
+|------|---------|-----------|
+| pork_chops | bg-orange-50 | #c2410c |
+| ham | bg-rose-50 | #be123c |
+| butter | bg-yellow-50 | #ca8a04 |
+| yogurt | bg-violet-50 | #7c3aed |
+| strawberries | bg-red-50 | #dc2626 |
+| white_bread | bg-amber-50 | #d97706 |
+| whole_wheat_bread | bg-orange-50 | #c2410c |
+| rice | bg-stone-50 | #78716c |
+| spaghetti | bg-yellow-50 | #ca8a04 |
+| flour | bg-neutral-50 | #737373 |
+| coffee | bg-stone-50 | #57534e |
+| natural_gas | bg-orange-50 | #ea580c |
+
+## Verification Results (2026-01-31)
+
+All 12 new national series IDs were verified against the BLS API v2 with data through December 2025.
+
+**Dropped from original draft (5 items):**
+- `turkey` (APU0000706311) -- BLS discontinued, last data Feb 2020
+- `tuna` (APU0000707111) -- invalid series ID, no data ever returned
+- `grapes` (APU0000711417) -- BLS discontinued, last data Sep 2021
+- `broccoli` (APU0000712412) -- BLS discontinued, last data Mar 2020
+- `peanut_butter` (APU0000716141) -- invalid series ID, no data ever returned
+
+## Implementation Steps
+
+1. Update `src/goods.json` with the new 6-category structure and all 27 items
+2. Run tests to confirm the worker handles the new structure
+3. Deploy and trigger a manual update via `POST /update` to populate R2
+
+## Notes
+
+- Eggs west region uses `APU0400708112` (not `708111`) -- preserved from existing config
+- Some items use alpha-prefixed item codes (FD, FS, FJ) rather than purely numeric codes. The worker handles these identically since it just passes series IDs to the BLS API.
+- Strawberries may have seasonal gaps where BLS doesn't publish if sample sizes are insufficient.
+
+## Sources
+
+- [BLS Average Price Data Factsheet](https://www.bls.gov/cpi/factsheets/average-prices.htm)
+- [BLS Average Price Publication List (item codes)](https://www.bls.gov/cpi/additional-resources/average-price-publication-list.htm)
+- [FRED Average Price Data](https://fred.stlouisfed.org/release?rid=454)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,15 @@
 			"devDependencies": {
 				"@cloudflare/vitest-pool-workers": "^0.5.2",
 				"vitest": "2.1.9",
-				"wrangler": "^4.58.0"
+				"wrangler": "^4.61.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz",
-			"integrity": "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+			"integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
-			"dependencies": {
-				"mime": "^3.0.0"
-			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
@@ -711,10 +708,20 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@img/colour": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+			"integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-			"integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+			"integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -731,13 +738,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.0.4"
+				"@img/sharp-libvips-darwin-arm64": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+			"integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
 			"cpu": [
 				"x64"
 			],
@@ -754,13 +761,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.0.4"
+				"@img/sharp-libvips-darwin-x64": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-			"integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+			"integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
 			"cpu": [
 				"arm64"
 			],
@@ -775,9 +782,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+			"integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
 			"cpu": [
 				"x64"
 			],
@@ -792,9 +799,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+			"integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
 			"cpu": [
 				"arm"
 			],
@@ -809,9 +816,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
 			"cpu": [
 				"arm64"
 			],
@@ -825,10 +832,44 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+			"integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
 		"node_modules/@img/sharp-libvips-linux-s390x": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-			"integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+			"integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -843,9 +884,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
 			"cpu": [
 				"x64"
 			],
@@ -860,9 +901,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-			"integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+			"integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -877,9 +918,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-			"integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+			"integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
 			"cpu": [
 				"x64"
 			],
@@ -894,9 +935,9 @@
 			}
 		},
 		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
 			"cpu": [
 				"arm"
 			],
@@ -913,13 +954,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.0.5"
+				"@img/sharp-libvips-linux-arm": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+			"integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
 			"cpu": [
 				"arm64"
 			],
@@ -936,13 +977,59 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.0.4"
+				"@img/sharp-libvips-linux-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+			"integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-linux-s390x": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-			"integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
 			"cpu": [
 				"s390x"
 			],
@@ -959,13 +1046,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-s390x": "1.0.4"
+				"@img/sharp-libvips-linux-s390x": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
 			"cpu": [
 				"x64"
 			],
@@ -982,13 +1069,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.0.4"
+				"@img/sharp-libvips-linux-x64": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-			"integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+			"integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1005,13 +1092,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-			"integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
 			"cpu": [
 				"x64"
 			],
@@ -1028,13 +1115,13 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4"
 			}
 		},
 		"node_modules/@img/sharp-wasm32": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-			"integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+			"integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1042,7 +1129,7 @@
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/runtime": "^1.2.0"
+				"@emnapi/runtime": "^1.7.0"
 			},
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1051,10 +1138,30 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+			"integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
 		"node_modules/@img/sharp-win32-ia32": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-			"integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+			"integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1072,9 +1179,9 @@
 			}
 		},
 		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+			"integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
 			"cpu": [
 				"x64"
 			],
@@ -1724,51 +1831,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/color": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1",
-				"color-string": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=12.5.0"
-			}
-		},
-		"node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -2006,13 +2068,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/is-arrayish": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-			"integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
@@ -2371,9 +2426,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2384,16 +2439,16 @@
 			}
 		},
 		"node_modules/sharp": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-			"integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"color": "^4.2.3",
-				"detect-libc": "^2.0.3",
-				"semver": "^7.6.3"
+				"@img/colour": "^1.0.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.7.3"
 			},
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -2402,25 +2457,30 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.33.5",
-				"@img/sharp-darwin-x64": "0.33.5",
-				"@img/sharp-libvips-darwin-arm64": "1.0.4",
-				"@img/sharp-libvips-darwin-x64": "1.0.4",
-				"@img/sharp-libvips-linux-arm": "1.0.5",
-				"@img/sharp-libvips-linux-arm64": "1.0.4",
-				"@img/sharp-libvips-linux-s390x": "1.0.4",
-				"@img/sharp-libvips-linux-x64": "1.0.4",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-				"@img/sharp-linux-arm": "0.33.5",
-				"@img/sharp-linux-arm64": "0.33.5",
-				"@img/sharp-linux-s390x": "0.33.5",
-				"@img/sharp-linux-x64": "0.33.5",
-				"@img/sharp-linuxmusl-arm64": "0.33.5",
-				"@img/sharp-linuxmusl-x64": "0.33.5",
-				"@img/sharp-wasm32": "0.33.5",
-				"@img/sharp-win32-ia32": "0.33.5",
-				"@img/sharp-win32-x64": "0.33.5"
+				"@img/sharp-darwin-arm64": "0.34.5",
+				"@img/sharp-darwin-x64": "0.34.5",
+				"@img/sharp-libvips-darwin-arm64": "1.2.4",
+				"@img/sharp-libvips-darwin-x64": "1.2.4",
+				"@img/sharp-libvips-linux-arm": "1.2.4",
+				"@img/sharp-libvips-linux-arm64": "1.2.4",
+				"@img/sharp-libvips-linux-ppc64": "1.2.4",
+				"@img/sharp-libvips-linux-riscv64": "1.2.4",
+				"@img/sharp-libvips-linux-s390x": "1.2.4",
+				"@img/sharp-libvips-linux-x64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+				"@img/sharp-linux-arm": "0.34.5",
+				"@img/sharp-linux-arm64": "0.34.5",
+				"@img/sharp-linux-ppc64": "0.34.5",
+				"@img/sharp-linux-riscv64": "0.34.5",
+				"@img/sharp-linux-s390x": "0.34.5",
+				"@img/sharp-linux-x64": "0.34.5",
+				"@img/sharp-linuxmusl-arm64": "0.34.5",
+				"@img/sharp-linuxmusl-x64": "0.34.5",
+				"@img/sharp-wasm32": "0.34.5",
+				"@img/sharp-win32-arm64": "0.34.5",
+				"@img/sharp-win32-ia32": "0.34.5",
+				"@img/sharp-win32-x64": "0.34.5"
 			}
 		},
 		"node_modules/siginfo": {
@@ -2429,16 +2489,6 @@
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-			"integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
@@ -3228,20 +3278,20 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.58.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.58.0.tgz",
-			"integrity": "sha512-Jm6EYtlt8iUcznOCPSMYC54DYkwrMNESzbH0Vh3GFHv/7XVw5gBC13YJAB+nWMRGJ+6B2dMzy/NVQS4ONL51Pw==",
+			"version": "4.61.1",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.61.1.tgz",
+			"integrity": "sha512-hfYQ16VLPkNi8xE1/V3052S2stM5e+vq3Idpt83sXoDC3R7R1CLgMkK6M6+Qp3G+9GVDNyHCkvohMPdfFTaD4Q==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
-				"@cloudflare/kv-asset-handler": "0.4.1",
-				"@cloudflare/unenv-preset": "2.8.0",
+				"@cloudflare/kv-asset-handler": "0.4.2",
+				"@cloudflare/unenv-preset": "2.12.0",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.0",
-				"miniflare": "4.20260107.0",
+				"miniflare": "4.20260128.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260107.1"
+				"workerd": "1.20260128.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -3254,7 +3304,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260107.1"
+				"@cloudflare/workers-types": "^4.20260128.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -3263,14 +3313,14 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.8.0.tgz",
-			"integrity": "sha512-oIAu6EdQ4zJuPwwKr9odIEqd8AV96z1aqi3RBEA4iKaJ+Vd3fvuI6m5EDC7/QCv+oaPIhy1SkYBYxmD09N+oZg==",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.12.0.tgz",
+			"integrity": "sha512-NK4vN+2Z/GbfGS4BamtbbVk1rcu5RmqaYGiyHJQrA09AoxdZPHDF3W/EhgI0YSK8p3vRo/VNCtbSJFPON7FWMQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"peerDependencies": {
 				"unenv": "2.0.0-rc.24",
-				"workerd": "^1.20251202.0"
+				"workerd": "^1.20260115.0"
 			},
 			"peerDependenciesMeta": {
 				"workerd": {
@@ -3279,9 +3329,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260107.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260107.1.tgz",
-			"integrity": "sha512-Srwe/IukVppkMU2qTndkFaKCmZBI7CnZoq4Y0U0gD/8158VGzMREHTqCii4IcCeHifwrtDqTWu8EcA1VBKI4mg==",
+			"version": "1.20260128.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260128.0.tgz",
+			"integrity": "sha512-XJN8zWWNG3JwAUqqwMLNKJ9fZfdlQkx/zTTHW/BB8wHat9LjKD6AzxqCu432YmfjR+NxEKCzUOxMu1YOxlVxmg==",
 			"cpu": [
 				"x64"
 			],
@@ -3296,9 +3346,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260107.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260107.1.tgz",
-			"integrity": "sha512-aAYwU7zXW+UZFh/a4vHP5cs1ulTOcDRLzwU9547yKad06RlZ6ioRm7ovjdYvdqdmbI8mPd99v4LN9gMmecazQw==",
+			"version": "1.20260128.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260128.0.tgz",
+			"integrity": "sha512-vKnRcmnm402GQ5DOdfT5H34qeR2m07nhnTtky8mTkNWP+7xmkz32AMdclwMmfO/iX9ncyKwSqmml2wPG32eq/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3313,9 +3363,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260107.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260107.1.tgz",
-			"integrity": "sha512-Wh7xWtFOkk6WY3CXe3lSqZ1anMkFcwy+qOGIjtmvQ/3nCOaG34vKNwPIE9iwryPupqkSuDmEqkosI1UUnSTh1A==",
+			"version": "1.20260128.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260128.0.tgz",
+			"integrity": "sha512-RiaR+Qugof/c6oI5SagD2J5wJmIfI8wQWaV2Y9905Raj6sAYOFaEKfzkKnoLLLNYb4NlXicBrffJi1j7R/ypUA==",
 			"cpu": [
 				"x64"
 			],
@@ -3330,9 +3380,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260107.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260107.1.tgz",
-			"integrity": "sha512-NI0/5rdssdZZKYHxNG4umTmMzODByq86vSCEk8u4HQbGhRCQo7rV1eXn84ntSBdyWBzWdYGISCbeZMsgfIjSTg==",
+			"version": "1.20260128.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260128.0.tgz",
+			"integrity": "sha512-U39U9vcXLXYDbrJ112Q7D0LDUUnM54oXfAxPgrL2goBwio7Z6RnsM25TRvm+Q06F4+FeDOC4D51JXlFHb9t1OA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3347,9 +3397,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260107.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260107.1.tgz",
-			"integrity": "sha512-gmBMqs606Gd/IhBEBPSL/hJAqy2L8IyPUjKtoqd/Ccy7GQxbSc0rYlRkxbQ9YzmqnuhrTVYvXuLscyWrpmAJkw==",
+			"version": "1.20260128.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260128.0.tgz",
+			"integrity": "sha512-fdJwSqRkJsAJFJ7+jy0th2uMO6fwaDA8Ny6+iFCssfzlNkc4dP/twXo+3F66FMLMe/6NIqjzVts0cpiv7ERYbQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3754,16 +3804,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/wrangler/node_modules/acorn-walk": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/wrangler/node_modules/cookie": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -3821,24 +3861,18 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/miniflare": {
-			"version": "4.20260107.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260107.0.tgz",
-			"integrity": "sha512-X93sXczqbBq9ixoM6jnesmdTqp+4baVC/aM/DuPpRS0LK0XtcqaO75qPzNEvDEzBAHxwMAWRIum/9hg32YB8iA==",
+			"version": "4.20260128.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260128.0.tgz",
+			"integrity": "sha512-AVCn3vDRY+YXu1sP4mRn81ssno6VUqxo29uY2QVfgxXU2TMLvhRIoGwm7RglJ3Gzfuidit5R86CMQ6AvdFTGAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
-				"acorn": "8.14.0",
-				"acorn-walk": "8.3.2",
-				"exit-hook": "2.2.1",
-				"glob-to-regexp": "0.4.1",
-				"sharp": "^0.33.5",
-				"stoppable": "1.1.0",
-				"undici": "7.14.0",
-				"workerd": "1.20260107.1",
+				"sharp": "^0.34.5",
+				"undici": "7.18.2",
+				"workerd": "1.20260128.0",
 				"ws": "8.18.0",
-				"youch": "4.1.0-beta.10",
-				"zod": "^3.25.76"
+				"youch": "4.1.0-beta.10"
 			},
 			"bin": {
 				"miniflare": "bootstrap.js"
@@ -3848,9 +3882,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/undici": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-			"integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+			"integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3858,9 +3892,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/workerd": {
-			"version": "1.20260107.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260107.1.tgz",
-			"integrity": "sha512-4ylAQJDdJZdMAUl2SbJgTa77YHpa88l6qmhiuCLNactP933+rifs7I0w1DslhUIFgydArUX5dNLAZnZhT7Bh7g==",
+			"version": "1.20260128.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260128.0.tgz",
+			"integrity": "sha512-EhLJGptSGFi8AEErLiamO3PoGpbRqL+v4Ve36H2B38VxmDgFOSmDhfepBnA14sCQzGf1AEaoZX2DCwZsmO74yQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -3872,11 +3906,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260107.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260107.1",
-				"@cloudflare/workerd-linux-64": "1.20260107.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260107.1",
-				"@cloudflare/workerd-windows-64": "1.20260107.1"
+				"@cloudflare/workerd-darwin-64": "1.20260128.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20260128.0",
+				"@cloudflare/workerd-linux-64": "1.20260128.0",
+				"@cloudflare/workerd-linux-arm64": "1.20260128.0",
+				"@cloudflare/workerd-windows-64": "1.20260128.0"
 			}
 		},
 		"node_modules/wrangler/node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.5.2",
 		"vitest": "2.1.9",
-		"wrangler": "^4.58.0"
+		"wrangler": "^4.61.0"
 	},
 	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/goods.json
+++ b/src/goods.json
@@ -1,23 +1,8 @@
 {
 	"categories": {
-		"meats": {
-			"name": "Meats",
+		"proteins": {
+			"name": "Proteins",
 			"items": {
-				"eggs": {
-					"name": "Eggs",
-					"dataKey": "eggs",
-					"icon": "🥚",
-					"unit": "dozen",
-					"bgColor": "bg-orange-50",
-					"lineColor": "#ea580c",
-					"seriesId": {
-						"national": "APU0000708111",
-						"northeast": "APU0100708111",
-						"midwest": "APU0200708111",
-						"south": "APU0300708111",
-						"west": "APU0400708112"
-					}
-				},
 				"chicken": {
 					"name": "Chicken",
 					"dataKey": "chicken",
@@ -62,12 +47,57 @@
 						"south": "APU0300704111",
 						"west": "APU0400704111"
 					}
+				},
+				"pork_chops": {
+					"name": "Pork Chops",
+					"dataKey": "pork_chops",
+					"icon": "🍖",
+					"unit": "pound",
+					"bgColor": "bg-orange-50",
+					"lineColor": "#c2410c",
+					"seriesId": {
+						"national": "APU0000FD3101",
+						"northeast": "APU0100FD3101",
+						"midwest": "APU0200FD3101",
+						"south": "APU0300FD3101",
+						"west": "APU0400FD3101"
+					}
+				},
+				"ham": {
+					"name": "Ham",
+					"dataKey": "ham",
+					"icon": "🐷",
+					"unit": "pound",
+					"bgColor": "bg-rose-50",
+					"lineColor": "#be123c",
+					"seriesId": {
+						"national": "APU0000FD2101",
+						"northeast": "APU0100FD2101",
+						"midwest": "APU0200FD2101",
+						"south": "APU0300FD2101",
+						"west": "APU0400FD2101"
+					}
 				}
 			}
 		},
-		"dairy": {
-			"name": "Dairy",
+		"dairy_eggs": {
+			"name": "Dairy & Eggs",
 			"items": {
+				"eggs": {
+					"name": "Eggs",
+					"dataKey": "eggs",
+					"icon": "🥚",
+					"unit": "dozen",
+					"bgColor": "bg-orange-50",
+					"lineColor": "#ea580c",
+					"seriesId": {
+						"national": "APU0000708111",
+						"northeast": "APU0100708111",
+						"midwest": "APU0200708111",
+						"south": "APU0300708111",
+						"west": "APU0400708112"
+					}
+				},
 				"milk": {
 					"name": "Whole Milk",
 					"dataKey": "milk",
@@ -112,11 +142,41 @@
 						"south": "APU0300710411",
 						"west": "APU0400710411"
 					}
+				},
+				"butter": {
+					"name": "Butter",
+					"dataKey": "butter",
+					"icon": "🧈",
+					"unit": "pound",
+					"bgColor": "bg-yellow-50",
+					"lineColor": "#ca8a04",
+					"seriesId": {
+						"national": "APU0000FS1101",
+						"northeast": "APU0100FS1101",
+						"midwest": "APU0200FS1101",
+						"south": "APU0300FS1101",
+						"west": "APU0400FS1101"
+					}
+				},
+				"yogurt": {
+					"name": "Yogurt",
+					"dataKey": "yogurt",
+					"icon": "🫙",
+					"unit": "8 oz",
+					"bgColor": "bg-violet-50",
+					"lineColor": "#7c3aed",
+					"seriesId": {
+						"national": "APU0000FJ4101",
+						"northeast": "APU0100FJ4101",
+						"midwest": "APU0200FJ4101",
+						"south": "APU0300FJ4101",
+						"west": "APU0400FJ4101"
+					}
 				}
 			}
 		},
-		"produce": {
-			"name": "Fruits and Vegetables",
+		"fruits": {
+			"name": "Fruits",
 			"items": {
 				"bananas": {
 					"name": "Bananas",
@@ -163,6 +223,26 @@
 						"west": "APU0400711411"
 					}
 				},
+				"strawberries": {
+					"name": "Strawberries",
+					"dataKey": "strawberries",
+					"icon": "🍓",
+					"unit": "12 oz",
+					"bgColor": "bg-red-50",
+					"lineColor": "#dc2626",
+					"seriesId": {
+						"national": "APU0000711415",
+						"northeast": "APU0100711415",
+						"midwest": "APU0200711415",
+						"south": "APU0300711415",
+						"west": "APU0400711415"
+					}
+				}
+			}
+		},
+		"vegetables": {
+			"name": "Vegetables",
+			"items": {
 				"potatoes": {
 					"name": "Potatoes",
 					"dataKey": "potatoes",
@@ -210,6 +290,101 @@
 				}
 			}
 		},
+		"pantry": {
+			"name": "Pantry",
+			"items": {
+				"white_bread": {
+					"name": "White Bread",
+					"dataKey": "white_bread",
+					"icon": "🍞",
+					"unit": "pound",
+					"bgColor": "bg-amber-50",
+					"lineColor": "#d97706",
+					"seriesId": {
+						"national": "APU0000702111",
+						"northeast": "APU0100702111",
+						"midwest": "APU0200702111",
+						"south": "APU0300702111",
+						"west": "APU0400702111"
+					}
+				},
+				"whole_wheat_bread": {
+					"name": "Whole Wheat Bread",
+					"dataKey": "whole_wheat_bread",
+					"icon": "🌾",
+					"unit": "pound",
+					"bgColor": "bg-orange-50",
+					"lineColor": "#c2410c",
+					"seriesId": {
+						"national": "APU0000702212",
+						"northeast": "APU0100702212",
+						"midwest": "APU0200702212",
+						"south": "APU0300702212",
+						"west": "APU0400702212"
+					}
+				},
+				"rice": {
+					"name": "Rice",
+					"dataKey": "rice",
+					"icon": "🍚",
+					"unit": "pound",
+					"bgColor": "bg-stone-50",
+					"lineColor": "#78716c",
+					"seriesId": {
+						"national": "APU0000701312",
+						"northeast": "APU0100701312",
+						"midwest": "APU0200701312",
+						"south": "APU0300701312",
+						"west": "APU0400701312"
+					}
+				},
+				"spaghetti": {
+					"name": "Spaghetti & Macaroni",
+					"dataKey": "spaghetti",
+					"icon": "🍝",
+					"unit": "pound",
+					"bgColor": "bg-yellow-50",
+					"lineColor": "#ca8a04",
+					"seriesId": {
+						"national": "APU0000701322",
+						"northeast": "APU0100701322",
+						"midwest": "APU0200701322",
+						"south": "APU0300701322",
+						"west": "APU0400701322"
+					}
+				},
+				"flour": {
+					"name": "Flour",
+					"dataKey": "flour",
+					"icon": "🌿",
+					"unit": "pound",
+					"bgColor": "bg-neutral-50",
+					"lineColor": "#737373",
+					"seriesId": {
+						"national": "APU0000701111",
+						"northeast": "APU0100701111",
+						"midwest": "APU0200701111",
+						"south": "APU0300701111",
+						"west": "APU0400701111"
+					}
+				},
+				"coffee": {
+					"name": "Coffee",
+					"dataKey": "coffee",
+					"icon": "☕",
+					"unit": "pound",
+					"bgColor": "bg-stone-50",
+					"lineColor": "#57534e",
+					"seriesId": {
+						"national": "APU0000717311",
+						"northeast": "APU0100717311",
+						"midwest": "APU0200717311",
+						"south": "APU0300717311",
+						"west": "APU0400717311"
+					}
+				}
+			}
+		},
 		"energy": {
 			"name": "Energy",
 			"items": {
@@ -241,6 +416,21 @@
 						"midwest": "APU020072610",
 						"south": "APU030072610",
 						"west": "APU040072610"
+					}
+				},
+				"natural_gas": {
+					"name": "Natural Gas",
+					"dataKey": "natural_gas",
+					"icon": "🔥",
+					"unit": "therm",
+					"bgColor": "bg-orange-50",
+					"lineColor": "#ea580c",
+					"seriesId": {
+						"national": "APU000072620",
+						"northeast": "APU010072620",
+						"midwest": "APU020072620",
+						"south": "APU030072620",
+						"west": "APU040072620"
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- Expand goods catalog from 15 items (4 categories) to 27 items (6 categories)
- Restructure categories: Proteins, Dairy & Eggs, Fruits, Vegetables, Pantry, Energy
- Add 12 new items with BLS-verified series IDs (verified 2026-01-31)
- Add design document with verification results and implementation notes

## Details

See `docs/plans/2026-01-31-expand-goods-catalog-design.md` for the full design, including dropped items (5 series discontinued or invalid) and verification results.

No changes to `src/worker.js` needed -- it iterates categories generically.

Closes #21
Related: #22, #23

## Test plan

- [ ] Validate goods.json parses correctly (27 items, 6 categories, all 5 regions)
- [ ] Run worker locally with `wrangler dev` and trigger `POST /update`
- [ ] Verify new item keys appear in R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)